### PR TITLE
Feat/tree segmenter mm ply

### DIFF
--- a/digiforest_analysis/src/digiforest_analysis/pipeline.py
+++ b/digiforest_analysis/src/digiforest_analysis/pipeline.py
@@ -87,14 +87,19 @@ class Pipeline:
 
     def save_cloud(self, cloud, label="default"):
         filename = Path(self._output_dir).joinpath(label + self._cloud_format)
-        header_fix = {"VIEWPOINT": self._header["VIEWPOINT"]}
+        if self._header is None:
+            header_fix = None
+        else:
+            header_fix = {"VIEWPOINT": self._header["VIEWPOINT"]}
         io.write(cloud, header_fix, str(filename))
 
     def save_trees(self, trees, label="trees"):
         save_folder = Path(self._output_dir).joinpath(label)
         save_folder.mkdir(parents=True, exist_ok=True)
-
-        header_fix = {"VIEWPOINT": self._header["VIEWPOINT"]}
+        if self._header is None:
+            header_fix = None
+        else:
+            header_fix = {"VIEWPOINT": self._header["VIEWPOINT"]}
 
         for tree in trees:
             # Write clouds
@@ -117,7 +122,7 @@ class Pipeline:
             self._cloud = cloud
             self._header = header
 
-        if self._cloud is None or self._header is None:
+        if self._cloud is None:
             raise ValueError("'cloud or header empty'")
 
         # Extract the ground

--- a/digiforest_analysis/src/digiforest_analysis/pipeline.py
+++ b/digiforest_analysis/src/digiforest_analysis/pipeline.py
@@ -87,19 +87,11 @@ class Pipeline:
 
     def save_cloud(self, cloud, label="default"):
         filename = Path(self._output_dir).joinpath(label + self._cloud_format)
-        if self._header is None:
-            header_fix = None
-        else:
-            header_fix = {"VIEWPOINT": self._header["VIEWPOINT"]}
-        io.write(cloud, header_fix, str(filename))
+        io.write(cloud, self._header, str(filename))
 
     def save_trees(self, trees, label="trees"):
         save_folder = Path(self._output_dir).joinpath(label)
         save_folder.mkdir(parents=True, exist_ok=True)
-        if self._header is None:
-            header_fix = None
-        else:
-            header_fix = {"VIEWPOINT": self._header["VIEWPOINT"]}
 
         for tree in trees:
             # Write clouds
@@ -110,7 +102,7 @@ class Pipeline:
             tree_cloud_filename = Path(
                 save_folder, f"tree_cloud_{i:04}{self._cloud_format}"
             )
-            io.write(tree_cloud, header_fix, str(tree_cloud_filename))
+            io.write(tree_cloud, self._header, str(tree_cloud_filename))
 
             # Write tree info
             tree_info_filename = Path(save_folder, f"tree_cloud_{i:04}.yaml")

--- a/digiforest_analysis/src/digiforest_analysis/utils/io.py
+++ b/digiforest_analysis/src/digiforest_analysis/utils/io.py
@@ -11,19 +11,9 @@ def load(filename: str, binary=True):
     file_format = path.suffix
     cloud = o3d.t.io.read_point_cloud(str(path))
 
-    # if the coordinates of the cloud are too large,
-    # apply an offset to avoid numerical issues
-    threshold = 10**6
-    if len(cloud.point.positions) > 0:
-        point = cloud.point.positions[0].numpy().copy()
-        if (
-            (np.abs(point[0]) > threshold)
-            or (np.abs(point[1]) > threshold)
-            or (np.abs(point[2]) > threshold)
-        ):
-            cloud = cloud.translate(-point)
-
-    header = load_header(filename, file_format, binary=binary)
+    header = load_header(filename, file_format, binary=binary, cloud=cloud)
+    if "offset" in header:
+        cloud = cloud.translate(-header["offset"])
 
     return cloud, header
 
@@ -49,12 +39,15 @@ def write_open3d(cloud, header, filename):
     path = Path(filename)
     file_format = path.suffix
 
+    if "offset" in header:
+        cloud.translate(header["offset"])
+
     # Write cloud to file
     o3d.io.write_point_cloud(filename, cloud.to_legacy())
 
     # Update header
     if header is not None:
-        original_header = load_header(filename, file_format, binary=True)
+        original_header = load_header(filename, file_format, binary=True, cloud=cloud)
         for k, v in header.items():
             original_header[k] = v
 
@@ -62,18 +55,21 @@ def write_open3d(cloud, header, filename):
         replace_file_header(filename, original_header, binary=True)
 
 
-def load_header(filename, file_format, binary=True):
+def load_header(filename, file_format, binary=True, cloud=None):
     if file_format == ".pcd":
         header = load_pcd_header(filename, binary=binary)
     elif file_format == ".ply":
-        header = load_ply_header(filename, binary=binary)
+        header = load_ply_header(filename, cloud, binary=binary)
     else:
         raise ValueError(f"Format {file_format} not suported")
+
+    header["format"] = file_format
     return header
 
 
 def load_pcd_header(filename, binary=True):
-    header = {"format": ".pcd"}
+    # This only loads the viewpoint
+    header = {}
 
     open_mode = "rb" if binary else "r"
     with open(filename, open_mode) as f:
@@ -83,14 +79,15 @@ def load_pcd_header(filename, binary=True):
             if line.startswith("#"):
                 continue
             if line.startswith("VERSION"):
-                key, value = line.split()
-                header[key] = value
+                continue
+                # key, value = line.split()
+                # header[key] = value
             elif (
-                line.startswith("FIELDS")
-                or line.startswith("SIZE")
-                or line.startswith("TYPE")
-                or line.startswith("COUNT")
-                or line.startswith("VIEWPOINT")
+                line.startswith("VIEWPOINT")
+                # or line.startswith("FIELDS")
+                # or line.startswith("SIZE")
+                # or line.startswith("TYPE")
+                # or line.startswith("COUNT")
             ):
                 parts = line.split()
                 key = parts[0]
@@ -101,17 +98,29 @@ def load_pcd_header(filename, binary=True):
                 or line.startswith("HEIGHT")
                 or line.startswith("POINTS")
             ):
-                key, value = line.split()
-                header[key] = int(value)
+                continue
+                # key, value = line.split()
+                # header[key] = int(value)
             elif line.startswith("DATA"):
                 # We ignore the data fields
                 break
     return header
 
 
-def load_ply_header(filename, binary=True):
-    return None
-    # raise NotImplementedError("load_ply_header")
+def load_ply_header(filename, cloud, binary=True):
+    # if the coordinates of the cloud are too large,
+    # the header will store an offset to avoid numerical issues
+    threshold = 10**6
+    header = {}
+    if len(cloud.point.positions) > 0:
+        point = cloud.point.positions[0].numpy().copy()
+        if (
+            (np.abs(point[0]) > threshold)
+            or (np.abs(point[1]) > threshold)
+            or (np.abs(point[2]) > threshold)
+        ):
+            header["offset"] = point
+    return header
 
 
 def replace_file_header(filename, header, binary=True):
@@ -143,25 +152,25 @@ def replace_pcd_file_header_binary(filename, header):
             # Parse file
             if line.startswith(b"#"):
                 pass
-            if line.startswith(b"VERSION"):
+            if line.startswith(b"VERSION") and "VERSION" in header:
                 key, value = line.decode().split()
                 # line.replace(line, (f"{key} {header[key]}\n").encode(encoding))
                 line = (f"{key} {header[key]}\n").encode(encoding)
             elif (
-                line.startswith(b"FIELDS")
-                or line.startswith(b"SIZE")
-                or line.startswith(b"TYPE")
-                or line.startswith(b"COUNT")
-                or line.startswith(b"VIEWPOINT")
+                (line.startswith(b"FIELDS") and "FIELDS" in header)
+                or (line.startswith(b"SIZE") and "SIZE" in header)
+                or (line.startswith(b"TYPE") and "TYPE" in header)
+                or (line.startswith(b"COUNT") and "COUNT" in header)
+                or (line.startswith(b"VIEWPOINT") and "VIEWPOINT" in header)
             ):
                 parts = line.decode().split()
                 key = parts[0]
                 # line.replace(line, (f"{key} " + " ".join(header[key]) + "\n").encode(encoding))
                 line = (f"{key} " + " ".join(header[key]) + "\n").encode(encoding)
             elif (
-                line.startswith(b"WIDTH")
-                or line.startswith(b"HEIGHT")
-                or line.startswith(b"POINTS")
+                (line.startswith(b"WIDTH") and "WIDTH" in header)
+                or (line.startswith(b"HEIGHT") and "HEIGHT" in header)
+                or (line.startswith(b"POINTS") and "POINTS" in header)
             ):
                 key, value = line.decode().split()
                 # line.replace(line, (f"{key} {header[key]}\n").encode(encoding))
@@ -176,4 +185,4 @@ def replace_pcd_file_header_binary(filename, header):
 
 
 def replace_ply_file_header(filename, header, binary=True):
-    raise NotImplementedError()
+    pass


### PR DESCRIPTION
@benoit-robotics I revised your changes and they were good. I modified the logic a bit to make the overal io procedures simpler. Now the header only stores:

- the format of the cloud
- `VIEWPOINT` if it is a `.pcd`, so we can rewrite the viewpoint in the exported clouds
- `offset` if it is a `.ply`, so we can offset it when we load it, and offset it back when we write it.

In that way all the saved clouds are consistent with the original cloud when loading them in CloudCompare, for example.

I'll merge this and we can discuss tomorrow.